### PR TITLE
Avoid sharing state across end-to-end test executions

### DIFF
--- a/EssentialFeed/EssentialFeedEndToEndTests/EssentialFeedEndToEndTests.swift
+++ b/EssentialFeed/EssentialFeedEndToEndTests/EssentialFeedEndToEndTests.swift
@@ -37,7 +37,7 @@ class EssentialFeedEndToEndTests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> LoadFeedResult? {
-        let client = URLSessionHTTPClient()
+        let client = URLSessionHTTPClient(session: URLSession(configuration: .ephemeral))
         let testServerURL = URL(string: "https://essentialdeveloper.com/feed-case-study/test-api/feed")!
         let loader = RemoteFeedLoader(client: client, url: testServerURL)
         trackForMemoryLeaks(client, file: file, line: line)


### PR DESCRIPTION
Use **ephemeral** URL session configuration to avoid sharing state across test executions