### PR TITLE
`CodableFeedStore` partial implementation (retrieve and insert happy path)

### DIFF
--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		080EDEFB21B6DA7E00813479 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 080EDEF121B6DA7E00813479 /* EssentialFeed.framework */; };
 		080EDF0C21B6DAE800813479 /* FeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080EDF0B21B6DAE800813479 /* FeedImage.swift */; };
 		080EDF0E21B6DCB600813479 /* FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080EDF0D21B6DCB600813479 /* FeedLoader.swift */; };
+		250672C62E5D9E7B00BE0815 /* CodableFeedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250672C52E5D9E7B00BE0815 /* CodableFeedStoreTests.swift */; };
 		250EDCEC2DF96ED000A38359 /* ValidateFeedCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250EDCEB2DF96ED000A38359 /* ValidateFeedCacheUseCaseTests.swift */; };
 		252649A52CFEE3E200D223A9 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252649A42CFEE3E200D223A9 /* RemoteFeedLoader.swift */; };
 		253A30E22D8163710083666D /* CacheFeedUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253A30E12D8163710083666D /* CacheFeedUseCaseTests.swift */; };
@@ -56,6 +57,7 @@
 		080EDF0121B6DA7E00813479 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		080EDF0B21B6DAE800813479 /* FeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImage.swift; sourceTree = "<group>"; };
 		080EDF0D21B6DCB600813479 /* FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoader.swift; sourceTree = "<group>"; };
+		250672C52E5D9E7B00BE0815 /* CodableFeedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableFeedStoreTests.swift; sourceTree = "<group>"; };
 		250EDCEB2DF96ED000A38359 /* ValidateFeedCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateFeedCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		252649A42CFEE3E200D223A9 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
 		253A30E12D8163710083666D /* CacheFeedUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFeedUseCaseTests.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 				253A30E12D8163710083666D /* CacheFeedUseCaseTests.swift */,
 				253F9E2C2DEFE53C000B323D /* LoadFeedFromCacheUseCaseTests.swift */,
 				250EDCEB2DF96ED000A38359 /* ValidateFeedCacheUseCaseTests.swift */,
+				250672C52E5D9E7B00BE0815 /* CodableFeedStoreTests.swift */,
 			);
 			path = "Feed Cache";
 			sourceTree = "<group>";
@@ -399,6 +402,7 @@
 				2570C6A92DFA5A0C009D9705 /* SharedTestHelpers.swift in Sources */,
 				253A30E22D8163710083666D /* CacheFeedUseCaseTests.swift in Sources */,
 				253F9E2D2DEFE53C000B323D /* LoadFeedFromCacheUseCaseTests.swift in Sources */,
+				250672C62E5D9E7B00BE0815 /* CodableFeedStoreTests.swift in Sources */,
 				25CCC6D02D0969920086C1C4 /* URLSessionHTTPClientTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImage.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImage.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct LocalFeedImage: Equatable, Codable {
+public struct LocalFeedImage: Equatable {
     public let id: UUID
     public let description: String?
     public let location: String?

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImage.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImage.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct LocalFeedImage: Equatable {
+public struct LocalFeedImage: Equatable, Codable {
     public let id: UUID
     public let description: String?
     public let location: String?

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -75,23 +75,13 @@ class CodableFeedStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        let storeURL = FileManager.default.urls(
-            for: .documentDirectory,
-            in: .userDomainMask
-        ).first!.appendingPathComponent("image-feed.store")
-        
-        try? FileManager.default.removeItem(at: storeURL)
+        try? FileManager.default.removeItem(at: storeURL())
     }
     
     override func tearDown() {
         super.tearDown()
         
-        let storeURL = FileManager.default.urls(
-            for: .documentDirectory,
-            in: .userDomainMask
-        ).first!.appendingPathComponent("image-feed.store")
-        
-        try? FileManager.default.removeItem(at: storeURL)
+        try? FileManager.default.removeItem(at: storeURL())
     }
     
     func test_retrieve_deliversEmptyOnEmptyCache() {
@@ -166,13 +156,15 @@ class CodableFeedStoreTests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> CodableFeedStore {
-        let storeURL = FileManager.default.urls(
-            for: .documentDirectory,
-            in: .userDomainMask
-        ).first!.appendingPathComponent("image-feed.store")
-        let sut = CodableFeedStore(storeURL: storeURL)
+        let sut = CodableFeedStore(storeURL: storeURL())
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
     }
     
+    private func storeURL() -> URL {
+        return FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first!.appendingPathComponent("image-feed.store")
+    }
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -161,8 +161,13 @@ class CodableFeedStoreTests: XCTestCase {
     
     // MARK: Helpers
     
-    private func makeSUT() -> CodableFeedStore {
-        return CodableFeedStore()
+    private func makeSUT(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> CodableFeedStore {
+        let sut = CodableFeedStore()
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return sut
     }
     
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -94,7 +94,7 @@ class CodableFeedStoreTests: XCTestCase {
     }
     
     func test_retrieve_deliversEmptyOnEmptyCache() {
-        let sut = CodableFeedStore()
+        let sut = makeSUT()
         let exp = expectation(description: "Wait for cache retrieval")
         
         sut.retrieve { result in
@@ -113,7 +113,7 @@ class CodableFeedStoreTests: XCTestCase {
     }
     
     func test_retrieve_hasNoSideEffectsOnEmptyCache() {
-        let sut = CodableFeedStore()
+        let sut = makeSUT()
         let exp = expectation(description: "Wait for cache retrieval")
         
         sut.retrieve { firstResult in
@@ -134,7 +134,7 @@ class CodableFeedStoreTests: XCTestCase {
     }
     
     func test_retrieveAfterInsertingToEmptyCache_deliversInsertedValues() {
-        let sut = CodableFeedStore()
+        let sut = makeSUT()
         let feed = uniqueImageFeed().local
         let timestamp = Date()
         let exp = expectation(description: "Wait for cache retrieval")
@@ -157,6 +157,12 @@ class CodableFeedStoreTests: XCTestCase {
         }
         
         wait(for: [exp], timeout: 1.0)
+    }
+    
+    // MARK: Helpers
+    
+    private func makeSUT() -> CodableFeedStore {
+        return CodableFeedStore()
     }
     
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -35,4 +35,25 @@ class CodableFeedStoreTests: XCTestCase {
         
     }
     
+    func test_retrieve_hasNoSideEffectsOnEmptyCache() {
+        let sut = CodableFeedStore()
+        let exp = expectation(description: "Wait for cache retrieval")
+        
+        sut.retrieve { firstResult in
+            sut.retrieve { secondResult in
+                switch (firstResult, secondResult) {
+                case (.empty, .empty):
+                    break
+                default:
+                    XCTFail("Expected retrieving twice from empty cache to deliver same empty result, got \(firstResult) and \(secondResult) instead")
+                }
+                
+                exp.fulfill()
+            }
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+        
+    }
+    
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -1,0 +1,38 @@
+//
+//  CodableFeedStoreTests.swift
+//  EssentialFeedTests
+//
+//  Created by Nayem, Mufakkharul | Nil | GSSD on 2025/08/26.
+//
+
+import XCTest
+import EssentialFeed
+
+class CodableFeedStore {
+    func retrieve(completion: @escaping FeedStore.RetrievalCompletion) {
+        completion(.empty)
+    }
+}
+
+class CodableFeedStoreTests: XCTestCase {
+    
+    func test_retrieve_deliversEmptyOnEmptyCache() {
+        let sut = CodableFeedStore()
+        let exp = expectation(description: "Wait for cache retrieval")
+        
+        sut.retrieve { result in
+            switch result {
+            case .empty:
+                break
+            default:
+                XCTFail("Expected empty result, got \(result) instead")
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+        
+    }
+    
+}

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -41,10 +41,11 @@ class CodableFeedStore {
         }
     }
     
-    private let storeURL = FileManager.default.urls(
-        for: .documentDirectory,
-        in: .userDomainMask
-    ).first!.appendingPathComponent("image-feed.store")
+    private let storeURL: URL
+    
+    init(storeURL: URL) {
+        self.storeURL = storeURL
+    }
     
     func retrieve(completion: @escaping FeedStore.RetrievalCompletion) {
         guard let data = try? Data(contentsOf: storeURL) else {
@@ -165,7 +166,11 @@ class CodableFeedStoreTests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> CodableFeedStore {
-        let sut = CodableFeedStore()
+        let storeURL = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first!.appendingPathComponent("image-feed.store")
+        let sut = CodableFeedStore(storeURL: storeURL)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
     }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -75,13 +75,13 @@ class CodableFeedStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        try? FileManager.default.removeItem(at: storeURL())
+        try? FileManager.default.removeItem(at: testSpecificStoreURL())
     }
     
     override func tearDown() {
         super.tearDown()
         
-        try? FileManager.default.removeItem(at: storeURL())
+        try? FileManager.default.removeItem(at: testSpecificStoreURL())
     }
     
     func test_retrieve_deliversEmptyOnEmptyCache() {
@@ -156,15 +156,15 @@ class CodableFeedStoreTests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> CodableFeedStore {
-        let sut = CodableFeedStore(storeURL: storeURL())
+        let sut = CodableFeedStore(storeURL: testSpecificStoreURL())
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
     }
     
-    private func storeURL() -> URL {
+    private func testSpecificStoreURL() -> URL {
         return FileManager.default.urls(
-            for: .documentDirectory,
+            for: .cachesDirectory,
             in: .userDomainMask
-        ).first!.appendingPathComponent("image-feed.store")
+        ).first!.appendingPathComponent("\(String(describing: self)).store")
     }
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -9,12 +9,61 @@ import XCTest
 import EssentialFeed
 
 class CodableFeedStore {
+    private struct Cache: Codable {
+        let feed: [LocalFeedImage]
+        let timestamp: Date
+    }
+    
+    private let storeURL = FileManager.default.urls(
+        for: .documentDirectory,
+        in: .userDomainMask
+    ).first!.appendingPathComponent("image-feed.store")
+    
     func retrieve(completion: @escaping FeedStore.RetrievalCompletion) {
-        completion(.empty)
+        guard let data = try? Data(contentsOf: storeURL) else {
+            return completion(.empty)
+        }
+        
+        let decoder = JSONDecoder()
+        let cache = try! decoder.decode(Cache.self, from: data)
+        completion(.found(feed: cache.feed, timestamp: cache.timestamp))
+    }
+    
+    func insert(
+        _ feed: [LocalFeedImage],
+        timestamp: Date,
+        completion: @escaping FeedStore.InsertionCompletion
+    ) {
+        let encoder = JSONEncoder()
+        let encoded = try! encoder.encode(Cache(feed: feed, timestamp: timestamp))
+        try! encoded.write(to: storeURL)
+        completion(nil)
     }
 }
 
 class CodableFeedStoreTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        
+        let storeURL = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first!.appendingPathComponent("image-feed.store")
+        
+        try? FileManager.default.removeItem(at: storeURL)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        let storeURL = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first!.appendingPathComponent("image-feed.store")
+        
+        try? FileManager.default.removeItem(at: storeURL)
+    }
     
     func test_retrieve_deliversEmptyOnEmptyCache() {
         let sut = CodableFeedStore()
@@ -54,6 +103,32 @@ class CodableFeedStoreTests: XCTestCase {
         
         wait(for: [exp], timeout: 1.0)
         
+    }
+    
+    func test_retrieveAfterInsertingToEmptyCache_deliversInsertedValues() {
+        let sut = CodableFeedStore()
+        let feed = uniqueImageFeed().local
+        let timestamp = Date()
+        let exp = expectation(description: "Wait for cache retrieval")
+        
+        sut.insert(feed, timestamp: timestamp) { insertionError in
+            XCTAssertNil(insertionError, "Expected feed to be inserted successfully")
+            
+            sut.retrieve { retrieveResult in
+                switch retrieveResult {
+                case let .found(retrievedFeed, retrievedTimestamp):
+                    XCTAssertEqual(retrievedFeed, feed)
+                    XCTAssertEqual(retrievedTimestamp, timestamp)
+                
+                default:
+                    XCTFail("Expected found result with feed: \(feed) and timestamp: \(timestamp), got \(retrieveResult) instead")
+                }
+                
+                exp.fulfill()
+            }
+        }
+        
+        wait(for: [exp], timeout: 1.0)
     }
     
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -75,13 +75,13 @@ class CodableFeedStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        try? FileManager.default.removeItem(at: testSpecificStoreURL())
+        setupEmptyStoreState()
     }
     
     override func tearDown() {
         super.tearDown()
         
-        try? FileManager.default.removeItem(at: testSpecificStoreURL())
+        undoStoreSideEffects()
     }
     
     func test_retrieve_deliversEmptyOnEmptyCache() {
@@ -159,6 +159,18 @@ class CodableFeedStoreTests: XCTestCase {
         let sut = CodableFeedStore(storeURL: testSpecificStoreURL())
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
+    }
+    
+    private func setupEmptyStoreState() {
+        deleteStoreArtifacts()
+    }
+    
+    private func undoStoreSideEffects() {
+        deleteStoreArtifacts()
+    }
+    
+    private func deleteStoreArtifacts() {
+        try? FileManager.default.removeItem(at: testSpecificStoreURL())
     }
     
     private func testSpecificStoreURL() -> URL {

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -10,8 +10,35 @@ import EssentialFeed
 
 class CodableFeedStore {
     private struct Cache: Codable {
-        let feed: [LocalFeedImage]
+        let feed: [CodableFeedImage]
         let timestamp: Date
+        
+        var localFeed: [LocalFeedImage] {
+            return feed.map { $0.local }
+        }
+    }
+    
+    private struct CodableFeedImage: Codable {
+        private let id: UUID
+        private let description: String?
+        private let location: String?
+        private let url: URL
+        
+        init(_ local: LocalFeedImage) {
+            id = local.id
+            description = local.description
+            location = local.location
+            url = local.url
+        }
+        
+        var local: LocalFeedImage {
+            return LocalFeedImage(
+                id: id,
+                description: description,
+                location: location,
+                url: url
+            )
+        }
     }
     
     private let storeURL = FileManager.default.urls(
@@ -26,7 +53,7 @@ class CodableFeedStore {
         
         let decoder = JSONDecoder()
         let cache = try! decoder.decode(Cache.self, from: data)
-        completion(.found(feed: cache.feed, timestamp: cache.timestamp))
+        completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
     }
     
     func insert(
@@ -35,7 +62,8 @@ class CodableFeedStore {
         completion: @escaping FeedStore.InsertionCompletion
     ) {
         let encoder = JSONEncoder()
-        let encoded = try! encoder.encode(Cache(feed: feed, timestamp: timestamp))
+        let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
+        let encoded = try! encoder.encode(cache)
         try! encoded.write(to: storeURL)
         completion(nil)
     }


### PR DESCRIPTION
- Retrieve
✅ Empty cache returns empty
✅ Empty cache twice returns empty (no side-effects)
✅ Non-empty cache returns data
    - Non-empty cache twice returns same data (no side-effects)
    - Error returns error (if applicable, e.g., invalid data)
    - Error twice returns same error (if applicable, e.g., invalid data)

- Insert
✅ To empty cache stores data
    - To non-empty cache overrides previous data with new data
    - Error (if applicable, e.g., no write permission)

- Delete
    - Empty cache does nothing (cache stays empty and does not fail)
    - Non-empty cache leaves cache empty
    - Error (if applicable, e.g., no delete permission)
- Side-effects must run serially to avoid race conditions